### PR TITLE
Add deque as velocity buffer

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,7 @@
 name: CI
 on:
   push:
-    branches: [ master ]
+    branches: [ humble ]
   pull_request:
 
 jobs:
@@ -36,4 +36,4 @@ jobs:
           target-ros2-distro: humble # TODO: Add iron once released
           skip-tests: true
           # TODO: Change to raw github link so it is runnable with act once the repository is set to public?
-          vcs-repo-file-url: "${{ github.workspace }}/igus_robot_control_ros2.repos" 
+          vcs-repo-file-url: "${{ github.workspace }}/irc_ros.repos" 

--- a/irc_ros_hardware/include/irc_ros_hardware/CAN/joint.hpp
+++ b/irc_ros_hardware/include/irc_ros_hardware/CAN/joint.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <bitset>
+#include <deque>
 #include <memory>
 #include <string>
 
@@ -48,6 +49,11 @@ private:
   //  Saves the timestamp from the last position message
   //  used to estimate the velocity
   CAN::t_timestamp last_stamp_;
+
+  // Used to filter the velocities
+  std::deque<double> velocity_buffer_;
+  static constexpr size_t max_velocity_buffer_size_ = 10;
+  std::array<double, max_velocity_buffer_size_> velocity_buffer_weights_;
 };
 
 }  // namespace irc_hardware

--- a/irc_ros_hardware/include/irc_ros_hardware/CAN/joint.hpp
+++ b/irc_ros_hardware/include/irc_ros_hardware/CAN/joint.hpp
@@ -52,8 +52,8 @@ private:
 
   // Used to filter the velocities
   std::deque<double> velocity_buffer_;
-  static constexpr size_t max_velocity_buffer_size_ = 10;
-  std::array<double, max_velocity_buffer_size_> velocity_buffer_weights_;
+  static constexpr size_t velocity_buffer_size_ = 10;
+  std::array<double, velocity_buffer_size_> velocity_buffer_weights_;
 };
 
 }  // namespace irc_hardware

--- a/irc_ros_hardware/include/irc_ros_hardware/CAN/module.hpp
+++ b/irc_ros_hardware/include/irc_ros_hardware/CAN/module.hpp
@@ -109,7 +109,7 @@ public:
   // Standard ROS2 Control controller variables
   double pos_ = std::numeric_limits<double>::quiet_NaN();
   double set_pos_ = std::numeric_limits<double>::quiet_NaN();
-  double vel = std::numeric_limits<double>::quiet_NaN();
+  double vel_ = std::numeric_limits<double>::quiet_NaN();
   double set_vel_ = std::numeric_limits<double>::quiet_NaN();
   double set_torque_ = std::numeric_limits<double>::quiet_NaN();
 

--- a/irc_ros_hardware/src/CAN/joint.cpp
+++ b/irc_ros_hardware/src/CAN/joint.cpp
@@ -7,30 +7,19 @@ namespace irc_hardware
 Joint::Joint(std::string name, std::shared_ptr<CAN::CanInterface> can_interface, int can_id)
 : Module::Module(name, can_interface, can_id)
 {
+  // Calculate the weighted moving average weights
   double divider = 0.0;
-  for (int i = 0; i < max_velocity_buffer_size_; i++) {
+  for (int i = 0; i < velocity_buffer_size_; i++) {
     divider += i + 1;
   }
 
-  for (int i = 0; i < max_velocity_buffer_size_; i++) {
-    velocity_buffer_weights_[i] = i + 1;
-    velocity_buffer_weights_[i] /= divider;
+  for (int i = 0; i < velocity_buffer_size_; i++) {
+    velocity_buffer_weights_[i] = (i + 1) / divider;
 
-    RCLCPP_ERROR(
-      rclcpp::get_logger("iRC_ROS"), "Module 0x%02x: Weight %d is %lf", can_id_, i,
-      velocity_buffer_weights_[i]);
-
-    // Fill the deque until it reaches its max size.
+    // Also fill the deque until it reaches its max size.
     // Otherwise the queue size would need to be handled dynamically.
     velocity_buffer_.push_front(0.0);
   }
-
-  // TODO: Remove this after testing
-  double sum = 0.0;
-  for (int i = 0; i < max_velocity_buffer_size_; i++) {
-    sum += velocity_buffer_weights_[i];
-  }
-  RCLCPP_ERROR(rclcpp::get_logger("iRC_ROS"), "Module 0x%02x: Weights sum is %lf", can_id_, sum);
 }
 
 Joint::~Joint()
@@ -294,7 +283,7 @@ void Joint::read_can()
       velocity_buffer_.push_front(new_vel);
 
       double sum = 0.0;
-      for (int i = 0; i < max_velocity_buffer_size_; i++) {
+      for (int i = 0; i < velocity_buffer_size_; i++) {
         sum += velocity_buffer_[i] * velocity_buffer_weights_[i];
       }
 

--- a/irc_ros_hardware/src/irc_ros_can.cpp
+++ b/irc_ros_hardware/src/irc_ros_can.cpp
@@ -334,7 +334,7 @@ std::vector<hardware_interface::StateInterface> IrcRosCan::export_state_interfac
     state_interfaces.emplace_back(hardware_interface::StateInterface(
       joint.name, hardware_interface::HW_IF_POSITION, &(modules_[joint.name]->pos_)));
     state_interfaces.emplace_back(hardware_interface::StateInterface(
-      joint.name, hardware_interface::HW_IF_VELOCITY, &(modules_[joint.name]->vel)));
+      joint.name, hardware_interface::HW_IF_VELOCITY, &(modules_[joint.name]->vel_)));
 
     //Dashboard specific states (same for gpios and joints)
     state_interfaces.emplace_back(hardware_interface::StateInterface(


### PR DESCRIPTION
While this is not yet nicely coded it adds a velocity buffer and a weighted moving average filter as can be seen below:
```
ros2_control_node-1] [ERROR] [1678381353.367514750] [iRC_ROS]: Module 0x60: Weight 0 is 0.018182
[ros2_control_node-1] [ERROR] [1678381353.367519044] [iRC_ROS]: Module 0x60: Weight 1 is 0.036364
[ros2_control_node-1] [ERROR] [1678381353.367523367] [iRC_ROS]: Module 0x60: Weight 2 is 0.054545
[ros2_control_node-1] [ERROR] [1678381353.367527302] [iRC_ROS]: Module 0x60: Weight 3 is 0.072727
[ros2_control_node-1] [ERROR] [1678381353.367531445] [iRC_ROS]: Module 0x60: Weight 4 is 0.090909
[ros2_control_node-1] [ERROR] [1678381353.367535097] [iRC_ROS]: Module 0x60: Weight 5 is 0.109091
[ros2_control_node-1] [ERROR] [1678381353.367538960] [iRC_ROS]: Module 0x60: Weight 6 is 0.127273
[ros2_control_node-1] [ERROR] [1678381353.367543133] [iRC_ROS]: Module 0x60: Weight 7 is 0.145455
[ros2_control_node-1] [ERROR] [1678381353.367547203] [iRC_ROS]: Module 0x60: Weight 8 is 0.163636
[ros2_control_node-1] [ERROR] [1678381353.367551389] [iRC_ROS]: Module 0x60: Weight 9 is 0.181818
[ros2_control_node-1] [ERROR] [1678381353.367555642] [iRC_ROS]: Module 0x60: Weights sum is 1.000000
```

Before merging cleanup and comparing the velocity output curve via PlotJuggler should be done.