### PR TITLE
Delay start of process thread

### DIFF
--- a/irc_ros_examples/README.md
+++ b/irc_ros_examples/README.md
@@ -2,22 +2,27 @@
 
 This package showcases how to implement Igus Robot Control ROS2 for different usecases.
 
-**Note: Starting the examples directly over the launch files in this package is not recommended as of now. The launch file does not wait for the moveit+ros2_control stack to be finished initialising, which causes jerky motions at startup**
 
 ## Pick&Place (MoveIt)
 ![](doc/pick_and_place.gif)
 
 This simple example showcases point-to-point, linear and axis movements, as well as how to interact with the gripper via its controller's service.
 
+The process runs in an infinite loop.
+
 For further MoveIt commands see [here](https://moveit.picknik.ai/humble/doc/examples/examples.html#using-moveit-directly-through-the-c-api).
 
 ### Usage
+There are two ways to start this example:
 
 ``` bash
-# Start moveit with the right gripper parameter
-$ LC_NUMERIC=en_US.UTF-8 ros2 launch irc_ros_moveit_config demo.launch.py gripper:="ext_dio_gripper"
+# Start MoveIt and the example node together
+$ LC_NUMERIC=en_US.UTF-8 ros2 launch irc_ros_examples pick_and_place.launch.py
 
-# Once the startup is complete run
+# Alternativly first start moveit with the right gripper parameter
+$ LC_NUMERIC=en_US.UTF-8 ros2 launch irc_ros_moveit_config rebel.launch.py gripper:="ext_dio_gripper"
+
+# Then, once the startup is complete, run:
 $ ros2 run irc_ros_examples pick_and_place
 ```
 
@@ -26,15 +31,20 @@ $ ros2 run irc_ros_examples pick_and_place
 
 Uses the Schmalz ECBPMI vacuum gripper for a vertical pick and place application. This showcases using the ECBPMI Controller, specifically how to use the service calls. It is also planned to use different coordinate systems for the different trays in the future.
 
+The process runs in an infinite loop.
+
 ### Usage
+There are two ways to start this example:
 
 ``` bash
-# Start moveit with the right gripper parameter
-$ LC_NUMERIC=en_US.UTF-8 ros2 launch irc_ros_moveit_config demo.launch.py gripper:="schmalz_ecbpmi"
+# Start MoveIt and the example node together
+$ LC_NUMERIC=en_US.UTF-8 ros2 launch irc_ros_examples pick_and_place_vacuum.launch.py
 
-# Once the startup is complete run:
+# Alternativly first start moveit with the right gripper parameter
+$ LC_NUMERIC=en_US.UTF-8 ros2 launch irc_ros_moveit_config rebel.launch.py gripper:="schmalz_ecbpmi"
+
+# Then, once the startup is complete, run:
 $ ros2 run irc_ros_examples pick_and_place_vacuum
-# This will run the process in an infinite loop
 ```
 
 ## Basic Navigation (Nav2 Simple Commander)

--- a/irc_ros_examples/include/irc_ros_examples/pick_and_place_base.hpp
+++ b/irc_ros_examples/include/irc_ros_examples/pick_and_place_base.hpp
@@ -43,7 +43,6 @@ public:
     print_pose(move_group->getCurrentPose().pose);
   }
 
-  // TODO: Does not exit cleanly with CTRL+C, requires a SIGKILL
   ~PickAndPlaceBase()
   {
     if (process_thread.joinable()) {

--- a/irc_ros_examples/src/pick_and_place.cpp
+++ b/irc_ros_examples/src/pick_and_place.cpp
@@ -19,12 +19,17 @@ public:
     gripper_publisher = move_group_node->create_publisher<irc_ros_msgs::msg::DioCommand>(
       "external_dio_controller/outputs", rclcpp::SystemDefaultsQoS());
 
-    // Run the process as long as possible
+    // Start the process loop in a new thread
     process_thread = std::thread([this]() {
+      // Wait a bit before sending commands so the initialisation can finish
+      std::this_thread::sleep_for(std::chrono::seconds(2));
+
+      // Run the process as long as possible
       while (rclcpp::ok()) {
         pick_and_place();
       }
     });
+
     process_thread.detach();
   }
 

--- a/irc_ros_examples/src/pick_and_place.cpp
+++ b/irc_ros_examples/src/pick_and_place.cpp
@@ -22,6 +22,7 @@ public:
     // Start the process loop in a new thread
     process_thread = std::thread([this]() {
       // Wait a bit before sending commands so the initialisation can finish
+      // TODO: Replace this with waiting for MoveIt/ros2_control to finish their inits
       std::this_thread::sleep_for(std::chrono::seconds(2));
 
       // Run the process as long as possible

--- a/irc_ros_examples/src/pick_and_place_vacuum.cpp
+++ b/irc_ros_examples/src/pick_and_place_vacuum.cpp
@@ -23,22 +23,25 @@ public:
 
     while (!gripper_client->wait_for_service(std::chrono::seconds(1))) {
       if (!rclcpp::ok()) {
-        RCLCPP_ERROR(LOGGER, "client interrupted while waiting for service to appear.");
+        RCLCPP_ERROR(LOGGER, "Client interrupted while waiting for service to appear.");
         return;
       }
-      RCLCPP_INFO(LOGGER, "waiting for service to appear...");
+      RCLCPP_INFO(LOGGER, "Waiting for ECBPMI gripper service to appear...");
     }
 
     RCLCPP_INFO(LOGGER, "Starting the pick and place process");
 
-
-    // Run the process as long as possible
+   // Start the process loop in a new thread
     process_thread = std::thread([this]() {
+      // Wait a bit before sending commands so the initialisation can finish
+      std::this_thread::sleep_for(std::chrono::seconds(2));
+
+      // Run the process as long as possible
       while (rclcpp::ok()) {
         pick_and_place_vacuum();
       }
     });
-    process_thread.detach();
+
   }
 
   /**

--- a/irc_ros_examples/src/pick_and_place_vacuum.cpp
+++ b/irc_ros_examples/src/pick_and_place_vacuum.cpp
@@ -34,6 +34,7 @@ public:
    // Start the process loop in a new thread
     process_thread = std::thread([this]() {
       // Wait a bit before sending commands so the initialisation can finish
+      // TODO: Replace this with waiting for MoveIt/ros2_control to finish their inits
       std::this_thread::sleep_for(std::chrono::seconds(2));
 
       // Run the process as long as possible


### PR DESCRIPTION
Instead of waiting for a signal/lifecycle change this simply delays the start by 2 seconds and thus lets the ReBeL initialize completly.