### PR TITLE
Add velocity and acceleration scaling functionality

### DIFF
--- a/irc_ros_examples/include/irc_ros_examples/pick_and_place_base.hpp
+++ b/irc_ros_examples/include/irc_ros_examples/pick_and_place_base.hpp
@@ -100,7 +100,7 @@ public:
       // Scale the trajectory
       if (velocity_scale != 1.0 || acceleration_scale != 1.0){
         trajectory_processing::IterativeParabolicTimeParameterization iptp;
-        robot_trajectory::RobotTrajectory rt(move_group->getRobotModel());
+        robot_trajectory::RobotTrajectory rt(move_group->getRobotModel(), PLANNING_GROUP);
         rt.setRobotTrajectoryMsg(*move_group->getCurrentState(), trajectory);
         bool scaling_successful = iptp.computeTimeStamps(rt, velocity_scale, acceleration_scale);
         if (!scaling_successful){

--- a/irc_ros_examples/include/irc_ros_examples/pick_and_place_base.hpp
+++ b/irc_ros_examples/include/irc_ros_examples/pick_and_place_base.hpp
@@ -15,6 +15,7 @@
 #include "irc_ros_msgs/srv/gripper_command.hpp"
 #include "moveit/move_group_interface/move_group_interface.h"
 #include "moveit/planning_scene_interface/planning_scene_interface.h"
+#include <moveit/trajectory_processing/iterative_time_parameterization.h>
 
 static const rclcpp::Logger LOGGER = rclcpp::get_logger("PickAndPlace");
 
@@ -73,7 +74,7 @@ public:
    * @param move_group Pointer to the MoveGroupInterface that shall be used for the movement
    * @param posestamped The pose that should be moved to from the move_groups current position
    */
-  void lin(geometry_msgs::msg::PoseStamped posestamped)
+  void lin(geometry_msgs::msg::PoseStamped posestamped, const double velocity_scale = 1.0, const double acceleration_scale = 1.0)
   {
     moveit_msgs::msg::RobotTrajectory trajectory;
     const double jump_threshold = 0.00;
@@ -93,10 +94,28 @@ public:
       move_group->setPoseTarget(posestamped, "hand");
       move_group->move();
     } else {
+      // Successful planning
       RCLCPP_INFO(LOGGER, "Accuracy %lf", fraction);
+
+      // Scale the trajectory
+      if (velocity_scale != 1.0 || acceleration_scale != 1.0){
+        trajectory_processing::IterativeParabolicTimeParameterization iptp;
+        robot_trajectory::RobotTrajectory rt(move_group->getRobotModel());
+        rt.setRobotTrajectoryMsg(*move_group->getCurrentState(), trajectory);
+        bool scaling_successful = iptp.computeTimeStamps(rt, velocity_scale, acceleration_scale);
+        if (!scaling_successful){
+          RCLCPP_WARN(
+            LOGGER, "Applying velocity or acceleration constraints failed!");
+        } else{
+          rt.getRobotTrajectoryMsg(trajectory);
+        } 
+      } 
+
       move_group->execute(trajectory);
     }
   }
+
+
 
 protected:
   // MoveIt specifics

--- a/irc_ros_examples/src/pick_and_place_vacuum.cpp
+++ b/irc_ros_examples/src/pick_and_place_vacuum.cpp
@@ -141,15 +141,18 @@ public:
 
     geometry_msgs::msg::PoseStamped target_pose;
 
+    // Move over the object
     target_pose= buffer_->transform(posestamped, planning_frame_);
     lin(target_pose);
 
+    // Slowly touch the object
     posestamped.pose.position.z -= height_offsetheight_offset_;
     target_pose= buffer_->transform(posestamped, planning_frame_);
-    lin(target_pose);
+    lin(target_pose, 0.2, 0.2);
 
     set_gripper(true);
 
+    // Lift the object
     posestamped.pose.position.z += height_offsetheight_offset_;
     target_pose= buffer_->transform(posestamped, planning_frame_);
     lin(target_pose);
@@ -176,19 +179,22 @@ public:
     posestamped.pose.orientation.z = 0;   
     
     geometry_msgs::msg::PoseStamped target_pose;
-    target_pose= buffer_->transform(posestamped, planning_frame_);
 
+    // Move over the slot
+    target_pose= buffer_->transform(posestamped, planning_frame_);
     lin(target_pose);
 
+    // Slowly touch the object
     posestamped.pose.position.z -= height_offsetheight_offset_;
     target_pose= buffer_->transform(posestamped, planning_frame_);
-    lin(target_pose);
+    lin(target_pose, 0.2, 0.2);
 
     set_gripper(false);
     // While the set_gripper fn blocks until the vacuum is gone or a timeout occurs
     // it takes a little longer than the vacuum gone signal for the object to disconnect
     std::this_thread::sleep_for(std::chrono::milliseconds(1500));
 
+    //Move back up again
     posestamped.pose.position.z += height_offsetheight_offset_;
     target_pose= buffer_->transform(posestamped, planning_frame_);
     lin(target_pose);

--- a/irc_ros_examples/src/pick_and_place_vacuum.cpp
+++ b/irc_ros_examples/src/pick_and_place_vacuum.cpp
@@ -148,7 +148,7 @@ public:
     // Slowly touch the object
     posestamped.pose.position.z -= height_offsetheight_offset_;
     target_pose= buffer_->transform(posestamped, planning_frame_);
-    lin(target_pose, 0.2, 0.2);
+    lin(target_pose, 0.1, 0.1);
 
     set_gripper(true);
 
@@ -187,7 +187,7 @@ public:
     // Slowly touch the object
     posestamped.pose.position.z -= height_offsetheight_offset_;
     target_pose= buffer_->transform(posestamped, planning_frame_);
-    lin(target_pose, 0.2, 0.2);
+    lin(target_pose, 0.1, 0.1);
 
     set_gripper(false);
     // While the set_gripper fn blocks until the vacuum is gone or a timeout occurs


### PR DESCRIPTION
While this compiles and looks like the correct way to interact with the limits the scaling fails with the error "It looks like the planner did not set the group the plan was computed for".

This occurs in this file:
https://github.com/ros-planning/moveit2/blob/humble/moveit_core/trajectory_processing/src/iterative_time_parameterization.cpp