### PR TITLE
Add callbacks and listen to reference, align and set to zero

### DIFF
--- a/irc_ros_hardware/include/irc_ros_hardware/CAN/joint.hpp
+++ b/irc_ros_hardware/include/irc_ros_hardware/CAN/joint.hpp
@@ -36,6 +36,10 @@ public:
   void write_can() override;
 
 private:
+  void set_position_to_zero_callback(cprcan::bytevec response);
+  void referencing_callback(cprcan::bytevec response);
+  void rotor_alignment_callback(cprcan::bytevec response);
+
   // Will be used for the zero-torque mode
   // bool zero_torque;
 

--- a/irc_ros_hardware/include/irc_ros_hardware/CAN/modulestates.hpp
+++ b/irc_ros_hardware/include/irc_ros_hardware/CAN/modulestates.hpp
@@ -76,7 +76,6 @@ enum class SetToZeroState {
   zeroing_step2,
   zeroing_step3,
   zeroing_step4,
-  zeroing_step5,
   zeroed,
 };
 
@@ -91,8 +90,6 @@ enum class ReferenceState {
   unreferenced,
   referencing_step1,
   referencing_step2,
-  referencing_step3,
-  referencing_step4,
   referenced,
 };
 
@@ -106,7 +103,6 @@ enum class RotorAlignmentState {
   unaligned,
   aligning_step1,
   aligning_step2,
-  aligning_step3,
   aligned,
 };
 

--- a/irc_ros_hardware/src/CAN/joint.cpp
+++ b/irc_ros_hardware/src/CAN/joint.cpp
@@ -123,9 +123,7 @@ void Joint::torque_cmd()
  * @brief Sets the current position as the new 0 offset. In most cases this should not be used.
  * Can be undone by the referencing function.
  * 
- * This gets called the first time by the user.
- * After that upon receiving a response it gets called again
- * from the message callback.
+ * This gets called by the user while the rest of the process is done in the callback
  *
  * TODO: This is untested
  */
@@ -142,15 +140,38 @@ void Joint::set_position_to_zero()
     can_interface_->write_message(message);
 
     setToZeroState = SetToZeroState::zeroing_step1;
-  } else if (setToZeroState == SetToZeroState::zeroing_step3) {
-    CAN::CanMessage message(can_id_, cprcan::set_pos_to_zero);
-    can_interface_->write_message(message);
-
-    setToZeroState = SetToZeroState::zeroing_step4;
   } else {
     RCLCPP_WARN(
       rclcpp::get_logger("iRC_ROS"),
-      "Module 0x%02x: setPositionToZero called while process is already running", can_id_);
+      "Module 0x%02x: setPositionToZero: Called while process is already running", can_id_);
+  }
+}
+
+void Joint::set_position_to_zero_callback(cprcan::bytevec response)
+{
+  if (
+    setToZeroState == SetToZeroState::zeroing_step1 &&
+    response == cprcan::set_pos_to_zero_response_1) {
+    setToZeroState = SetToZeroState::zeroing_step2;
+  } else if (
+    setToZeroState == SetToZeroState::zeroing_step2 &&
+    response == cprcan::set_pos_to_zero_response_2) {
+    CAN::CanMessage message(can_id_, cprcan::set_pos_to_zero);
+    can_interface_->write_message(message);
+
+    setToZeroState = SetToZeroState::zeroing_step3;
+  } else if (
+    setToZeroState == SetToZeroState::zeroing_step3 &&
+    response == cprcan::set_pos_to_zero_response_3) {
+    setToZeroState = SetToZeroState::zeroing_step4;
+  } else if (
+    setToZeroState == SetToZeroState::zeroing_step4 &&
+    response == cprcan::set_pos_to_zero_response_4) {
+    setToZeroState = SetToZeroState::zeroed;
+  } else {
+    RCLCPP_WARN(
+      rclcpp::get_logger("iRC_ROS"), "Module 0x%02x: setPositionToZero: Unexpected response",
+      can_id_);
   }
 }
 
@@ -159,26 +180,45 @@ void Joint::set_position_to_zero()
  * absolute encoders and it is not necessary as it is done on startup already. For DIN-RAIL
  * modules it is required to be done on startup.
  * 
- * This gets called the first time by the user.
- * After that upon receiving a response it gets called again
- * from the message callback.
+ * This gets called by the user while the rest of the process is done in the callback
  */
 void Joint::referencing()
 {
-  if (referenceState == ReferenceState::unreferenced) {
+  if (
+    referenceState == ReferenceState::unreferenced ||
+    referenceState == ReferenceState::not_required) {
     CAN::CanMessage message(can_id_, cprcan::referencing);
     can_interface_->write_message(message);
 
     referenceState = ReferenceState::referencing_step1;
-  } else if (referenceState == ReferenceState::referencing_step2) {
-    CAN::CanMessage message(can_id_, cprcan::referencing);
-    can_interface_->write_message(message);
-
-    referenceState = ReferenceState::referencing_step3;
   } else {
     RCLCPP_WARN(
       rclcpp::get_logger("iRC_ROS"),
-      "Module 0x%02x: referencing called while process is already running", can_id_);
+      "Module 0x%02x: Referencing: Called while process is already running", can_id_);
+  }
+}
+
+void Joint::referencing_callback(cprcan::bytevec response)
+{
+  if (
+    referenceState == ReferenceState::referencing_step1 &&
+    response == cprcan::referencing_response_1) {
+    CAN::CanMessage message(can_id_, cprcan::referencing);
+    can_interface_->write_message(message);
+
+    referenceState = ReferenceState::referencing_step2;
+  } else if (
+    referenceState == ReferenceState::referencing_step2 &&
+    response == cprcan::referencing_response_2) {
+    referenceState = ReferenceState::referenced;
+  } else if (response == cprcan::referencing_response_error) {
+    RCLCPP_ERROR(
+      rclcpp::get_logger("iRC_ROS"),
+      "Module 0x%02x: Referencing: Referencing has already been started", can_id_);
+  } else {
+    RCLCPP_WARN(
+      rclcpp::get_logger("iRC_ROS"), "Module 0x%02x: Referencing: Unexpected response received",
+      can_id_);
   }
 }
 
@@ -187,9 +227,7 @@ void Joint::referencing()
  * This is done during powering up automatically and is not needed to be called manually under normal
  * circumstances.
  * 
- * This gets called the first time by the user.
- * After that upon receiving a response it gets called again
- * from the message callback.
+ * This gets called by the user while the rest of the process is done in the callback
  *
  * TODO: This is untested.
 */
@@ -200,12 +238,30 @@ void Joint::rotor_alignment()
     can_interface_->write_message(message);
 
     rotorAlignmentState = RotorAlignmentState::aligning_step1;
-  } else if (rotorAlignmentState == RotorAlignmentState::aligning_step2) {
-    rotorAlignmentState = RotorAlignmentState::aligning_step3;
   } else {
     RCLCPP_WARN(
       rclcpp::get_logger("iRC_ROS"),
-      "Module 0x%02x: rotorAlignment called while process is already running", can_id_);
+      "Module 0x%02x: Aligning: Called while process is already running", can_id_);
+  }
+}
+
+void Joint::rotor_alignment_callback(cprcan::bytevec response)
+{
+  if (
+    rotorAlignmentState == RotorAlignmentState::aligning_step1 &&
+    response == cprcan::rotor_alignment_response_1) {
+    CAN::CanMessage message(can_id_, cprcan::rotor_alignment);
+    can_interface_->write_message(message);
+
+    rotorAlignmentState = RotorAlignmentState::aligning_step2;
+  } else if (
+    rotorAlignmentState == RotorAlignmentState::aligning_step2 &&
+    response == cprcan::rotor_alignment_response_2) {
+    rotorAlignmentState = RotorAlignmentState::aligned;
+  } else {
+    RCLCPP_WARN(
+      rclcpp::get_logger("iRC_ROS"), "Module 0x%02x: Aligning: Unexpected response received",
+      can_id_);
   }
 }
 
@@ -335,8 +391,6 @@ void Joint::read_can()
       // Same principle as for referenced above
       referenceState = ReferenceState::unreferenced;
     }
-
-    // TODO: Add SetToZero handling here
   }
 
   //control cmd received
@@ -349,6 +403,14 @@ void Joint::read_can()
 
       // Dont set it to finished quite yet, wait for the error bit to be 0;
       // resetState = ResetState::reset;
+    } else if (message.data == cprcan::set_pos_to_zero_response_1) {
+      set_position_to_zero_callback(message.data);
+    } else if (message.data == cprcan::set_pos_to_zero_response_2) {
+      set_position_to_zero_callback(message.data);
+    } else if (message.data == cprcan::set_pos_to_zero_response_3) {
+      set_position_to_zero_callback(message.data);
+    } else if (message.data == cprcan::set_pos_to_zero_response_4) {
+      set_position_to_zero_callback(message.data);
     } else if (message.data == cprcan::enable_motor_response) {
       if (motorState != MotorState::enabled) {
         RCLCPP_INFO(rclcpp::get_logger("iRC_ROS"), "Module 0x%02x: Motor enabled", can_id_);
@@ -359,6 +421,16 @@ void Joint::read_can()
         RCLCPP_INFO(rclcpp::get_logger("iRC_ROS"), "Module 0x%02x: Motor disabled", can_id_);
         motorState = MotorState::disabled;
       }
+    } else if (message.data == cprcan::referencing_response_1) {
+      referencing_callback(message.data);
+    } else if (message.data == cprcan::referencing_response_2) {
+      referencing_callback(message.data);
+    } else if (message.data == cprcan::referencing_response_error) {
+      referencing_callback(message.data);
+    } else if (message.data == cprcan::rotor_alignment_response_1) {
+      rotor_alignment_callback(message.data);
+    } else if (message.data == cprcan::rotor_alignment_response_2) {
+      rotor_alignment_callback(message.data);
     } else if (cprcan::data_has_header(message.data, cprcan::encoder_msg_header)) {
       // Output enc pos
       encoder_pos_ = (message.data[4] << 24) + (message.data[5] << 16) + (message.data[6] << 8) +


### PR DESCRIPTION
Tested with ReBeL modules only yet. While the process is not 100% stable as depending on the module state not all messages are always sent, the goal of the command seems to be executed just fine. Further testing before merging should be done in any case.