### PR TITLE
8 Limit CAN input queue size

### DIFF
--- a/irc_ros_hardware/include/irc_ros_hardware/CAN/can_interface.hpp
+++ b/irc_ros_hardware/include/irc_ros_hardware/CAN/can_interface.hpp
@@ -115,8 +115,8 @@ protected:
 
 private:
   std::mutex map_mutex_;
-  size_t warn_message_queue_size_ = 10;
-  size_t max_message_queue_size_ = 20;
+  size_t warn_message_queue_size_ = 5;
+  size_t max_message_queue_size_ = 7;
 
   /**
     * @brief Buffer of the last incoming messages of each CAN ID

--- a/irc_ros_hardware/include/irc_ros_hardware/CAN/can_interface.hpp
+++ b/irc_ros_hardware/include/irc_ros_hardware/CAN/can_interface.hpp
@@ -115,6 +115,8 @@ protected:
 
 private:
   std::mutex map_mutex_;
+  size_t warn_message_queue_size_ = 10;
+  size_t max_message_queue_size_ = 20;
 
   /**
     * @brief Buffer of the last incoming messages of each CAN ID

--- a/irc_ros_hardware/src/CAN/can_interface.cpp
+++ b/irc_ros_hardware/src/CAN/can_interface.cpp
@@ -177,6 +177,12 @@ void CanInterface::add_message_to_buffer(const TimedCanMessage & message)
 {
   const std::lock_guard<std::mutex> lock(map_mutex_);
   message_buffer_[message.id].push(message);
+  if (message_buffer_[message.id].size() > max_message_queue_size_) {
+    RCLCPP_WARN(rclcpp::get_logger("iRC_ROS::CAN"), "CAN ids 0x%02x message buffer has grown over max allowed size, dropping oldest message", message.id);
+    message_buffer_[message.id].pop();
+  } else if (message_buffer_[message.id].size() > warn_message_queue_size_) {
+    RCLCPP_WARN(rclcpp::get_logger("iRC_ROS::CAN"), "CAN ids 0x%02x message buffer is growing more than expected", message.id);
+  } 
 }
 
 /**

--- a/irc_ros_hardware/src/CAN/joint.cpp
+++ b/irc_ros_hardware/src/CAN/joint.cpp
@@ -275,7 +275,7 @@ void Joint::read_can()
   CAN::TimedCanMessage message;
 
   // Standard response
-  if (can_interface_->get_next_message(can_id_ + 1, message)) {
+  while (can_interface_->get_next_message(can_id_ + 1, message)) {
     RCLCPP_DEBUG(
       rclcpp::get_logger("iRC_ROS"), "Module 0x%02x: Standard response received", can_id_);
 
@@ -394,7 +394,7 @@ void Joint::read_can()
   }
 
   //control cmd received
-  if (can_interface_->get_next_message(can_id_ + 2, message)) {
+  while (can_interface_->get_next_message(can_id_ + 2, message)) {
     RCLCPP_DEBUG(rclcpp::get_logger("iRC_ROS"), "Module 0x%02x: Control cmd received", can_id_);
 
     if (message.data == cprcan::reset_error_response) {
@@ -479,7 +479,7 @@ void Joint::read_can()
       // to evaluate any unexplainable errors.
     }
   }
-  if (can_interface_->get_next_message(can_id_ + 3, message)) {
+  while (can_interface_->get_next_message(can_id_ + 3, message)) {
     if (cprcan::data_has_header(message.data, cprcan::environmental_msg_header)) {
       // Environmental parameters
 


### PR DESCRIPTION
This limits the input queue of the CAN interface, thus solving the problem with outdated messages causing jerky movement. Additionally now all available messages are read out in each read_can() call.