### PR TITLE
HardwareInterface error for single module errors

### DIFF
--- a/irc_ros_hardware/include/irc_ros_hardware/CAN/module.hpp
+++ b/irc_ros_hardware/include/irc_ros_hardware/CAN/module.hpp
@@ -127,6 +127,7 @@ public:
   // meaning that the heartbeat is interrupted and the controller goes into a COM error.
   bool may_reset_ = false;
 
+  ResetState resetState = ResetState::not_reset;
 protected:
   std::bitset<8> digital_in_;
   std::bitset<8> digital_out_;
@@ -139,7 +140,6 @@ protected:
   ErrorState lastErrorState;
   SetToZeroState setToZeroState = SetToZeroState::not_zeroed;
   RotorAlignmentState rotorAlignmentState = RotorAlignmentState::unaligned;
-  ResetState resetState = ResetState::not_reset;
 
   // TimePoints for timeouting failed commands
   std::chrono::time_point<std::chrono::steady_clock> motor_state_time_point_;

--- a/irc_ros_hardware/src/CAN/module.cpp
+++ b/irc_ros_hardware/src/CAN/module.cpp
@@ -134,7 +134,7 @@ void Module::prepare_movement()
     set_pos_ = pos_;
   }
 
-  if (errorState.any_except_mne()) {
+  if (errorState.any()) {
     RCLCPP_INFO(
       rclcpp::get_logger("iRC_ROS"), "Module 0x%02x: Errors%s detected, resetting", can_id_,
       errorState.str().c_str());
@@ -144,7 +144,7 @@ void Module::prepare_movement()
     reset_error(true);
   }
 
-  if (motorState != MotorState::enabled) {
+  if (!errorState.any_except_mne() && motorState != MotorState::enabled) {
     RCLCPP_DEBUG(
       rclcpp::get_logger("iRC_ROS"), "Module 0x%02x: Motor not enabled, enabling before movement",
       can_id_);

--- a/irc_ros_hardware/src/irc_ros_can.cpp
+++ b/irc_ros_hardware/src/irc_ros_can.cpp
@@ -374,6 +374,10 @@ hardware_interface::return_type IrcRosCan::read(
     module->read_can();
     module->update_double_copies();
     module->dashboard_command();
+  
+    if(module->errorState.any() && !module->may_reset_){
+      return hardware_interface::return_type::ERROR;
+    }
   }
 
   return hardware_interface::return_type::OK;

--- a/irc_ros_hardware/src/irc_ros_can.cpp
+++ b/irc_ros_hardware/src/irc_ros_can.cpp
@@ -375,9 +375,12 @@ hardware_interface::return_type IrcRosCan::read(
     module->update_double_copies();
     module->dashboard_command();
   
-    if(module->errorState.any() && !module->may_reset_){
+    // If an error occurs (except MNE because that seems buggy with some modules ATM, TODO: FIX)
+    // and we are neither in the process of fixing the error nor have the option to reset the error
+    // then stop the hardware interface to avoid unforseen movements.
+    if(module->errorState.any() && module->resetState != ResetState::resetting && module->motorState != MotorState::enabling && !module->may_reset_){
       RCLCPP_ERROR(
-        rclcpp::get_logger("iRC_ROS"), "0x%2x: Error detected, stopping hardware interface", module->can_id_);
+        rclcpp::get_logger("iRC_ROS"), "0x%2x: Error detected with no recovery option, stopping entire hardware interface for safety reasons", module->can_id_);
 
       return hardware_interface::return_type::ERROR;
     }

--- a/irc_ros_hardware/src/irc_ros_can.cpp
+++ b/irc_ros_hardware/src/irc_ros_can.cpp
@@ -376,6 +376,9 @@ hardware_interface::return_type IrcRosCan::read(
     module->dashboard_command();
   
     if(module->errorState.any() && !module->may_reset_){
+      RCLCPP_ERROR(
+        rclcpp::get_logger("iRC_ROS"), "0x%2x: Error detected, stopping hardware interface", module->can_id_);
+
       return hardware_interface::return_type::ERROR;
     }
   }


### PR DESCRIPTION
This adds a check to the read method of the CAN hardware interface that makes sure the entire hardware interface stops once a single module has an unrecoverable error. This is not tested besides making sure it compiles as of yet.