### PR TITLE
Only start crpcan specific controllers when the protocol is selected

### DIFF
--- a/irc_ros_bringup/launch/cpr_platform.launch.py
+++ b/irc_ros_bringup/launch/cpr_platform.launch.py
@@ -11,6 +11,7 @@ from launch.substitutions import (
     Command,
     FindExecutable,
     PathJoinSubstitution,
+    PythonExpression,
     LaunchConfiguration,
 )
 from launch_ros.actions import Node
@@ -111,7 +112,7 @@ def generate_launch_description():
     # platform_name = LaunchConfiguration('platform_name')
     platform_urdf = LaunchConfiguration("platform_urdf")
     platform_controller_config = LaunchConfiguration("platform_controller_config")
-    use_laserscanners = LaunchConfiguration("use_laserscanners")
+    # use_laserscanners = LaunchConfiguration("use_laserscanners")
     hardware_protocol = LaunchConfiguration("hardware_protocol")
 
     robot_description = Command(
@@ -212,7 +213,18 @@ def generate_launch_description():
             "namespace": namespace,
             "prefix": prefix,
         }.items(),
-        condition=IfCondition(use_laserscanners),
+        condition=IfCondition(
+            PythonExpression(
+                [
+                    "'",
+                    LaunchConfiguration("hardware_protocol"),
+                    "' == 'cprcanv2' ",
+                    "and '",
+                    LaunchConfiguration("use_laserscanners"),
+                    "' in ['1', 'true', 'True']",
+                ]
+            )
+        ),
     )
 
     # Since the odometry topics from the diffdrive controllers output to frames with a

--- a/irc_ros_bringup/launch/rebel.launch.py
+++ b/irc_ros_bringup/launch/rebel.launch.py
@@ -1,12 +1,16 @@
 from launch import LaunchDescription
-from launch.substitutions import Command, FindExecutable, PathJoinSubstitution
+from launch.actions import DeclareLaunchArgument, RegisterEventHandler
+from launch.conditions import IfCondition
+from launch.event_handlers import OnProcessExit
+from launch.substitutions import (
+    Command,
+    FindExecutable,
+    LaunchConfiguration,
+    PathJoinSubstitution,
+    PythonExpression,
+)
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
-
-from launch.actions import DeclareLaunchArgument, RegisterEventHandler
-from launch.conditions import IfCondition, LaunchConfigurationEquals
-from launch.substitutions import LaunchConfiguration
-from launch.event_handlers import OnProcessExit
 
 
 def generate_launch_description():
@@ -195,7 +199,18 @@ def generate_launch_description():
         executable="spawner",
         namespace=namespace,
         arguments=["dio_controller", "-c", controller_manager_name],
-        condition=LaunchConfigurationEquals("launch_dio_controller", "true"),
+        condition=IfCondition(
+            PythonExpression(
+                [
+                    "'",
+                    LaunchConfiguration("hardware_protocol"),
+                    "' == 'cprcanv2' ",
+                    "and '",
+                    LaunchConfiguration("launch_dio_controller"),
+                    "' in ['1', 'true', 'True']",
+                ]
+            )
+        ),
     )
 
     external_dio_controller_node = Node(
@@ -203,7 +218,18 @@ def generate_launch_description():
         executable="spawner",
         namespace=namespace,
         arguments=["external_dio_controller", "-c", controller_manager_name],
-        condition=LaunchConfigurationEquals("gripper", "ext_dio_gripper"),
+        condition=IfCondition(
+            PythonExpression(
+                [
+                    "'",
+                    LaunchConfiguration("hardware_protocol"),
+                    "' == 'cprcanv2' ",
+                    "and '",
+                    LaunchConfiguration("gripper"),
+                    "' == 'ext_dio_gripper' ",
+                ]
+            )
+        ),
     )
 
     ecbpmi_controller_node = Node(
@@ -211,7 +237,18 @@ def generate_launch_description():
         executable="spawner",
         namespace=namespace,
         arguments=["ecbpmi_controller", "-c", controller_manager_name],
-        condition=LaunchConfigurationEquals("gripper", "schmalz_ecbpmi"),
+        condition=IfCondition(
+            PythonExpression(
+                [
+                    "'",
+                    LaunchConfiguration("hardware_protocol"),
+                    "' == 'cprcanv2' ",
+                    "and '",
+                    LaunchConfiguration("gripper"),
+                    "' == 'schmalz_ecbpmi' ",
+                ]
+            )
+        ),
     )
 
     dashboard_controller_node = Node(
@@ -219,7 +256,22 @@ def generate_launch_description():
         executable="spawner",
         namespace=namespace,
         arguments=["dashboard_controller", "-c", controller_manager_name],
-        condition=LaunchConfigurationEquals("launch_dashboard_controller", "true"),
+        # condition=AndSubstitution(
+        #    LaunchConfigurationEquals("hardware_protocol", "cprcanv2"),
+        #    LaunchConfigurationEquals("launch_dashboard_controller", "true"),
+        # ),
+        condition=IfCondition(
+            PythonExpression(
+                [
+                    "'",
+                    LaunchConfiguration("hardware_protocol"),
+                    "' == 'cprcanv2' ",
+                    "and '",
+                    LaunchConfiguration("launch_dashboard_controller"),
+                    "' in ['1', 'true', 'True']",
+                ]
+            )
+        ),
     )
 
     # Delay start of robot_controller after `joint_state_broadcaster`

--- a/irc_ros_bringup/launch/rebel.launch.py
+++ b/irc_ros_bringup/launch/rebel.launch.py
@@ -163,7 +163,7 @@ def generate_launch_description():
         parameters=[
             {
                 "source_list": [
-                    "/joint_states",  # TODO: Does this need a namespace as well?
+                    "/joint_states",
                 ],
                 "rate": 30,
             }
@@ -256,10 +256,6 @@ def generate_launch_description():
         executable="spawner",
         namespace=namespace,
         arguments=["dashboard_controller", "-c", controller_manager_name],
-        # condition=AndSubstitution(
-        #    LaunchConfigurationEquals("hardware_protocol", "cprcanv2"),
-        #    LaunchConfigurationEquals("launch_dashboard_controller", "true"),
-        # ),
         condition=IfCondition(
             PythonExpression(
                 [


### PR DESCRIPTION
I made the launch conditions depend on multiple parameters and for that needed to write some ugly PythonExpression as the other solutions didn't work:

``` Python
# Doesn't work as LCE() is not iterable
AndSubstitution(LaunchConfigurationEquals(), LaunchConfigurationEquals())

# Only available in rolling/iron, but we target only humble right now
condition=AndSubstitution(
      EqualsSubstitution(LaunchConfiguration('hardware_protocol'), 'cprcanv2'),
      EqualsSubstitution(LaunchConfiguration('gripper'), 'ext_dio_gripper'),
),
```

It is currently only done for the rebel launch file, if testing doesn't show any errors I'll add this change to the other launch files as well