### PR TITLE
Fix losing LaunchConfigurations with EventHandlers for top level launch files

### DIFF
--- a/irc_ros_bringup/launch/cpr_platform.launch.py
+++ b/irc_ros_bringup/launch/cpr_platform.launch.py
@@ -1,11 +1,9 @@
 from launch import LaunchDescription
 from launch.actions import (
-    RegisterEventHandler,
     DeclareLaunchArgument,
     IncludeLaunchDescription,
 )
 from launch.conditions import IfCondition
-from launch.event_handlers import OnProcessExit
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import (
     Command,
@@ -179,16 +177,6 @@ def generate_launch_description():
         arguments=["cpr_platform_controller", "-c", controller_manager_name],
     )
 
-    # Delay start of robot_controller after `joint_state_broadcaster`
-    delay_robot_controller_spawner_after_joint_state_broadcaster_spawner = (
-        RegisterEventHandler(
-            event_handler=OnProcessExit(
-                target_action=joint_state_broadcaster,
-                on_exit=[robot_controller_node],
-            )
-        )
-    )
-
     rviz_node = Node(
         package="rviz2",
         executable="rviz2",
@@ -290,13 +278,15 @@ def generate_launch_description():
     description.add_action(hardware_protocol_arg)
 
     # Robot nodes
-    description.add_action(control_node)
     description.add_action(robot_state_pub)
     description.add_action(joint_state_pub)
+
+    # ROS2 Control nodes
+    description.add_action(control_node)
     description.add_action(joint_state_broadcaster)
-    description.add_action(
-        delay_robot_controller_spawner_after_joint_state_broadcaster_spawner
-    )
+    # Dont delay start of the following nodes after `joint_state_broadcaster` as the EventHandler
+    # causes issues with LaunchConfigurations
+    description.add_action(robot_controller_node)
 
     # UI nodes
     description.add_action(rviz_node)

--- a/irc_ros_bringup/launch/rebel_on_platform.launch.py
+++ b/irc_ros_bringup/launch/rebel_on_platform.launch.py
@@ -104,13 +104,14 @@ def generate_launch_description():
     use_rviz = LaunchConfiguration("use_rviz")
     rviz_file = LaunchConfiguration("rviz_file")
     robot_controller_config = LaunchConfiguration("robot_controller_config")
-    # hardware_protocol = LaunchConfiguration("hardware_protocol")
 
     # Use GroupActions for scoping the launch arguments, e.g. to not overwrite rviz arg
     rebel_stack = GroupAction(
         [
             IncludeLaunchDescription(
-                PythonLaunchDescriptionSource([irc_ros_bringup_launch_dir, "/rebel.launch.py"]),
+                PythonLaunchDescriptionSource(
+                    [irc_ros_bringup_launch_dir, "/rebel.launch.py"]
+                ),
                 launch_arguments={
                     "namespace": "/rebel_1",
                     "prefix": "rebel_1_",
@@ -122,7 +123,7 @@ def generate_launch_description():
                     "launch_dio_controller": "false",
                 }.items(),
             )
-        ] 
+        ]
     )
 
     platform_stack = GroupAction(
@@ -132,7 +133,6 @@ def generate_launch_description():
                     [irc_ros_bringup_launch_dir, "/cpr_platform.launch.py"]
                 ),
                 launch_arguments={
-                    "namespace": "",
                     # "namespace": "/platform",
                     # "prefix": "platform_",
                     # "controller_manager_name" : "/platform/controller_manager",

--- a/irc_ros_bringup/launch/rebel_on_platform.launch.py
+++ b/irc_ros_bringup/launch/rebel_on_platform.launch.py
@@ -20,7 +20,7 @@ def generate_launch_description():
     )
     default_robot_controller_filename_arg = DeclareLaunchArgument(
         "default_robot_controller_filename",
-        default_value="controller_igus_rebel_6dof_namespace_1",
+        default_value="controller_igus_rebel_6dof_namespace_1.yaml",
         description="Name of the robot controller configuration file",
     )
     default_robot_controller_file = PathJoinSubstitution(
@@ -107,20 +107,22 @@ def generate_launch_description():
     # hardware_protocol = LaunchConfiguration("hardware_protocol")
 
     # Use GroupActions for scoping the launch arguments, e.g. to not overwrite rviz arg
-    rebel_stack = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource([irc_ros_bringup_launch_dir, "/rebel.launch.py"]),
-        launch_arguments={
-            "namespace": "/rebel_1",
-            "prefix": "rebel_1_",
-            "controller_manager_name": "/rebel_1/controller_manager",
-            "use_rviz": "false",
-            "robot_controller_config": robot_controller_config,
-            "gripper": "none",
-            # "hardware_protocol": hardware_protocol,
-            "launch_dashboard_controller": "false",
-            "launch_dio_controller": "false",
-            "hardware_protocol": "cprcanv2",
-        }.items(),
+    rebel_stack = GroupAction(
+        [
+            IncludeLaunchDescription(
+                PythonLaunchDescriptionSource([irc_ros_bringup_launch_dir, "/rebel.launch.py"]),
+                launch_arguments={
+                    "namespace": "/rebel_1",
+                    "prefix": "rebel_1_",
+                    "controller_manager_name": "/rebel_1/controller_manager",
+                    "robot_controller_config": robot_controller_config,
+                    "gripper": "none",
+                    "use_rviz": "false",
+                    "launch_dashboard_controller": "false",
+                    "launch_dio_controller": "false",
+                }.items(),
+            )
+        ] 
     )
 
     platform_stack = GroupAction(
@@ -140,11 +142,9 @@ def generate_launch_description():
                     "launch_dio_controller": "false",
                     "use_rviz": "false",
                     "use_rqt_robot_steering": "true",
-                    "hardware_protocol": "cprcanv2",
                 }.items(),
             )
-        ],
-        forwarding=False,
+        ]
     )
 
     rviz_node = Node(


### PR DESCRIPTION
This PR removes the EventHandlers again from rebel and cpr_platform launch files and fixes some small issues with the launch files rebel_on_platform and two_rebels