### PR TITLE
adds velocity state interface to the cri hardware interface.

### DIFF
--- a/irc_ros_hardware/include/irc_ros_hardware/irc_ros_cri.hpp
+++ b/irc_ros_hardware/include/irc_ros_hardware/irc_ros_cri.hpp
@@ -43,6 +43,7 @@ private:
 
   // Read joint position values
   std::vector<double> pos;  // [rad]
+  std::vector<double> vel;  // [rad/s] 
 
   // Values given from the hardware_interface, all have length of N_JOINTS; predefine?
   std::vector<double> set_pos;  // [rad]

--- a/irc_ros_hardware/src/irc_ros_cri.cpp
+++ b/irc_ros_hardware/src/irc_ros_cri.cpp
@@ -315,6 +315,7 @@ hardware_interface::CallbackReturn IrcRosCri::on_init(const hardware_interface::
 
     jog_array.push_back(0.0f);
     pos.push_back(0.0f);
+    vel.push_back(0.0f);
     set_pos.push_back(0.0f);
     set_pos_last.push_back(0.0f);
     set_vel.push_back(0.0f);
@@ -390,6 +391,9 @@ std::vector<hardware_interface::StateInterface> IrcRosCri::export_state_interfac
   for (int i = 0; i < info_.joints.size(); i++) {
     state_interfaces.emplace_back(hardware_interface::StateInterface(
       info_.joints[i].name, hardware_interface::HW_IF_POSITION, &pos[i]));
+
+    state_interfaces.emplace_back(hardware_interface::StateInterface(
+      info_.joints[i].name, hardware_interface::HW_IF_VELOCITY, &vel[i]));
   }
 
   // TODO: DIO specific state_interfaces


### PR DESCRIPTION
The velocity is only initialized, not written or read. This seems necessary because the controller expects an interface to be there.